### PR TITLE
feat: localize menus and add permanent session deletion

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -4,7 +4,68 @@ window.__ModuleLoader__.load({
     const module = { exports: {} }
     const KEY = Symbol.for("dsh.session-context-menu.extensions")
     const LEASE = Symbol.for("dsh.session-context-menu.lease")
-    const CSS = `.dshcm-menu{position:fixed;z-index:2147483647;width:max-content;min-width:148px;max-width:260px;padding:4px;background:var(--dsw-alias-bg-layer-2,#fff);color:var(--dsw-alias-label-primary,#161616);border:1px solid var(--dsw-alias-border-l2,#ddd);border-radius:7px;box-shadow:0 5px 16px #00000029;font:13px/18px system-ui,sans-serif}.dshcm-item{box-sizing:border-box;width:100%;height:30px;padding:0 8px;text-align:left;white-space:nowrap;color:inherit;background:transparent;border:0;border-radius:5px;cursor:pointer;display:flex;gap:16px;align-items:center;justify-content:space-between}.dshcm-item:hover,.dshcm-item:focus-visible{background:var(--dsw-alias-interactive-bg-hover,#0000000f);outline:none}.dshcm-shortcut{color:var(--dsw-alias-label-tertiary,#777);font-size:11px}.dshcm-separator{height:1px;margin:4px -4px;background:var(--dsw-alias-border-l2,#ddd)}.dshcm-toast{position:fixed;z-index:2147483647;left:50%;bottom:28px;transform:translateX(-50%);padding:7px 12px;border-radius:7px;background:#222;color:#fff;font:13px/18px system-ui,sans-serif;box-shadow:0 6px 20px #0003}`
+    const CSS = `.dshcm-menu{position:fixed;z-index:2147483647;width:max-content;min-width:148px;max-width:260px;padding:4px;background:var(--dsw-alias-bg-layer-2,#fff);color:var(--dsw-alias-label-primary,#161616);border:1px solid var(--dsw-alias-border-l2,#ddd);border-radius:7px;box-shadow:0 5px 16px #00000029;font:13px/18px system-ui,sans-serif}.dshcm-item{box-sizing:border-box;width:100%;height:30px;padding:0 8px;text-align:left;white-space:nowrap;color:inherit;background:transparent;border:0;border-radius:5px;cursor:pointer;display:flex;gap:16px;align-items:center;justify-content:space-between}.dshcm-item:hover,.dshcm-item:focus-visible{background:var(--dsw-alias-interactive-bg-hover,#0000000f);outline:none}.dshcm-item--danger{color:var(--dsw-alias-state-error-primary,#d93025)}.dshcm-shortcut{color:var(--dsw-alias-label-tertiary,#777);font-size:11px}.dshcm-separator{height:1px;margin:4px -4px;background:var(--dsw-alias-border-l2,#ddd)}.dshcm-toast{position:fixed;z-index:2147483647;left:50%;bottom:28px;transform:translateX(-50%);padding:7px 12px;border-radius:7px;background:#222;color:#fff;font:13px/18px system-ui,sans-serif;box-shadow:0 6px 20px #0003}.dshcm-dialog-backdrop{position:fixed;z-index:2147483647;inset:0;display:grid;place-items:center;padding:20px;background:#0006}.dshcm-dialog{box-sizing:border-box;width:min(420px,100%);padding:20px;background:var(--dsw-alias-bg-layer-2,#fff);color:var(--dsw-alias-label-primary,#161616);border:1px solid var(--dsw-alias-border-l2,#ddd);border-radius:12px;box-shadow:0 18px 50px #0005;font:14px/21px system-ui,sans-serif}.dshcm-dialog-title{margin:0 0 10px;font-size:17px;line-height:24px;font-weight:650}.dshcm-dialog-message{margin:0;white-space:pre-line;color:var(--dsw-alias-label-secondary,#555)}.dshcm-dialog-actions{display:flex;justify-content:flex-end;gap:8px;margin-top:22px}.dshcm-dialog-button{min-width:72px;height:34px;padding:0 14px;border:1px solid var(--dsw-alias-border-l2,#ccc);border-radius:7px;background:var(--dsw-alias-bg-layer-1,#fff);color:inherit;cursor:pointer;font:inherit}.dshcm-dialog-button:hover,.dshcm-dialog-button:focus-visible{background:var(--dsw-alias-interactive-bg-hover,#0000000f);outline:2px solid var(--dsw-alias-state-focus,#6b9eff);outline-offset:1px}.dshcm-dialog-confirm{border-color:transparent;background:var(--dsw-alias-state-error-primary,#d93025);color:#fff}.dshcm-dialog-confirm:hover,.dshcm-dialog-confirm:focus-visible{background:var(--dsw-alias-state-error-primary,#c5221f)}`
+    const MESSAGES = {
+      zh: {
+        renameSession: "重命名会话", archiveSession: "归档会话", deleteSession: "删除会话", openInExplorer: "在资源管理器中打开",
+        copyWorkingDirectory: "复制工作目录", copySessionId: "复制会话 ID", forkSession: "创建会话分支",
+        refresh: "刷新", newSession: "新建会话", renameWorkspace: "重命名工作区",
+        copyWorkspacePath: "复制工作区路径", archiveWorkspaceSessions: "归档工作区会话", removeWorkspace: "移除工作区",
+        undo: "撤销", redo: "重做", cut: "剪切", copy: "复制", paste: "粘贴", selectAll: "全选",
+        copySelectedText: "复制所选文本", openInDefaultBrowser: "使用默认浏览器打开", copyLink: "复制链接",
+        selectCurrentContent: "全选当前内容", copiedWorkingDirectory: "已复制工作目录", copiedSessionId: "已复制会话 ID",
+        copiedWorkspacePath: "已复制工作区路径", sessionRenamed: "会话已重命名", sessionArchived: "会话已归档",
+        workspaceRemoved: "已移除工作区", copied: "已复制", cutDone: "已剪切", linkCopied: "已复制链接",
+        noWorkspaceSessions: "该工作区没有可归档的会话", archiveWorkspaceConfirm: "归档“{title}”中的 {count} 个会话？",
+        workspaceSessionsArchived: "已归档 {count} 个会话", removeWorkspaceConfirm: "从 Harness 中移除工作区“{title}”？\n\n目录、文件和会话日志不会被删除。",
+        officialSessionActionUnavailable: "当前会话尚未提供该官方操作", officialWorkspaceActionUnavailable: "找不到官方工作区操作",
+        openFailed: "打开失败: {reason}", unknownError: "未知错误", clipboardUnavailable: "剪贴板不可用",
+        clipboardReadFailed: "无法读取剪贴板，请使用 Ctrl+V", useUndoShortcut: "请使用 Ctrl+Z 撤销", useRedoShortcut: "请使用 Ctrl+Y 重做",
+        officialRenameUnavailable: "无法打开官方重命名窗口", officialWorkspaceRenameUnavailable: "无法打开官方工作区重命名窗口",
+        officialArchiveUnavailable: "无法调用官方归档会话", officialForkUnavailable: "无法调用官方分叉会话",
+        sessionUnknown: "无法确定当前会话", sessionNameEmpty: "会话名称不能为空", sessionServiceUnavailable: "无法取得官方会话服务",
+        renameFailed: "重命名失败", editPositionUnknown: "无法确定编辑位置", deleteSessionDialogTitle: "永久删除会话？", deleteSessionConfirm: "会话“{title}”的记录及其硬盘文件将被删除。\n\n此操作不可恢复。",
+        confirmDelete: "确定删除", cancel: "取消",
+        sessionDeleted: "会话已永久删除", sessionRunning: "会话仍在运行，无法删除", subagentSession: "子代理会话不能直接删除",
+        sessionNotFound: "找不到该会话", sessionFilesNotFound: "找不到该会话的本地文件", deleteFailed: "删除会话失败",
+      },
+      en: {
+        renameSession: "Rename session", archiveSession: "Archive session", deleteSession: "Delete session", openInExplorer: "Open in File Explorer",
+        copyWorkingDirectory: "Copy working directory", copySessionId: "Copy session ID", forkSession: "Fork session",
+        refresh: "Refresh", newSession: "New session", renameWorkspace: "Rename workspace",
+        copyWorkspacePath: "Copy workspace path", archiveWorkspaceSessions: "Archive workspace sessions", removeWorkspace: "Remove workspace",
+        undo: "Undo", redo: "Redo", cut: "Cut", copy: "Copy", paste: "Paste", selectAll: "Select all",
+        copySelectedText: "Copy selected text", openInDefaultBrowser: "Open in default browser", copyLink: "Copy link",
+        selectCurrentContent: "Select current content", copiedWorkingDirectory: "Working directory copied", copiedSessionId: "Session ID copied",
+        copiedWorkspacePath: "Workspace path copied", sessionRenamed: "Session renamed", sessionArchived: "Session archived",
+        workspaceRemoved: "Workspace removed", copied: "Copied", cutDone: "Cut", linkCopied: "Link copied",
+        noWorkspaceSessions: "This workspace has no sessions to archive", archiveWorkspaceConfirm: "Archive {count} sessions in “{title}”?",
+        workspaceSessionsArchived: "Archived {count} sessions", removeWorkspaceConfirm: "Remove workspace “{title}” from Harness?\n\nIts directory, files, and session logs will not be deleted.",
+        officialSessionActionUnavailable: "The official action is not available for this session", officialWorkspaceActionUnavailable: "Official workspace actions could not be found",
+        openFailed: "Failed to open: {reason}", unknownError: "Unknown error", clipboardUnavailable: "Clipboard is unavailable",
+        clipboardReadFailed: "Could not read the clipboard; use Ctrl+V", useUndoShortcut: "Use Ctrl+Z to undo", useRedoShortcut: "Use Ctrl+Y to redo",
+        officialRenameUnavailable: "Could not open the official rename dialog", officialWorkspaceRenameUnavailable: "Could not open the official workspace rename dialog",
+        officialArchiveUnavailable: "Could not invoke the official archive action", officialForkUnavailable: "Could not invoke the official fork action",
+        sessionUnknown: "Could not determine the current session", sessionNameEmpty: "Session name cannot be empty", sessionServiceUnavailable: "Official session service is unavailable",
+        renameFailed: "Rename failed", editPositionUnknown: "Could not determine the editing position", deleteSessionDialogTitle: "Permanently delete session?", deleteSessionConfirm: "The record and files on disk for session “{title}” will be deleted.\n\nThis cannot be undone.",
+        confirmDelete: "Delete", cancel: "Cancel",
+        sessionDeleted: "Session permanently deleted", sessionRunning: "The session is still running and cannot be deleted", subagentSession: "Subagent sessions cannot be deleted directly",
+        sessionNotFound: "Session not found", sessionFilesNotFound: "The session's local files could not be found", deleteFailed: "Failed to delete session",
+      },
+    }
+
+    function locale() {
+      const language = document.documentElement.lang || document.body?.getAttribute("lang") || ""
+      if (language) return language.toLocaleLowerCase().startsWith("zh") ? "zh" : "en"
+      const labels = [...document.querySelectorAll('button[aria-label]')].map((node) => node.getAttribute("aria-label") || "")
+      if (labels.some((label) => /会话|工作区/.test(label))) return "zh"
+      if (labels.some((label) => /session|workspace/i.test(label))) return "en"
+      return (navigator.language || "").toLocaleLowerCase().startsWith("zh") ? "zh" : "en"
+    }
+
+    function t(key, values = {}) {
+      return (MESSAGES[locale()][key] || MESSAGES.en[key] || key).replace(/\{(\w+)\}/g, (_, name) => values[name] ?? "")
+    }
 
     function registry() {
       if (!globalThis[KEY]) {
@@ -100,7 +161,7 @@ window.__ModuleLoader__.load({
         await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
         action = officialAction(row)
       }
-      if (!action) throw new Error("当前会话尚未提供该官方操作")
+      if (!action) throw new Error(t("officialSessionActionUnavailable"))
       action.click()
       setTimeout(() => {
         const item = [...document.querySelectorAll('[role="menuitem"]')].find((node) =>
@@ -116,7 +177,7 @@ window.__ModuleLoader__.load({
 
     function officialWorkspaceSelect(row, labels, failureMessage) {
       const action = [...row.querySelectorAll('button[aria-label]')].find(isWorkspaceAction)
-      if (!action) throw new Error("找不到官方工作区操作")
+      if (!action) throw new Error(t("officialWorkspaceActionUnavailable"))
       action.click()
       setTimeout(() => {
         const item = [...document.querySelectorAll('[role="menuitem"]')].find((node) =>
@@ -162,6 +223,69 @@ window.__ModuleLoader__.load({
       setTimeout(() => node.remove(), 1800)
     }
 
+    function confirmDialog({ title, message, confirmLabel, cancelLabel }) {
+      document.querySelector(".dshcm-dialog-backdrop")?.querySelector("[data-cancel]")?.click()
+      return new Promise((resolve) => {
+        const previousFocus = document.activeElement
+        const backdrop = document.createElement("div")
+        backdrop.className = "dshcm-dialog-backdrop"
+        const dialog = document.createElement("div")
+        dialog.className = "dshcm-dialog"
+        dialog.setAttribute("role", "alertdialog")
+        dialog.setAttribute("aria-modal", "true")
+        dialog.setAttribute("aria-labelledby", "dshcm-dialog-title")
+        dialog.setAttribute("aria-describedby", "dshcm-dialog-description")
+        const heading = document.createElement("h2")
+        heading.id = "dshcm-dialog-title"
+        heading.className = "dshcm-dialog-title"
+        heading.textContent = title
+        const description = document.createElement("p")
+        description.id = "dshcm-dialog-description"
+        description.className = "dshcm-dialog-message"
+        description.textContent = message
+        const actions = document.createElement("div")
+        actions.className = "dshcm-dialog-actions"
+        const cancel = document.createElement("button")
+        cancel.type = "button"
+        cancel.className = "dshcm-dialog-button"
+        cancel.dataset.cancel = ""
+        cancel.textContent = cancelLabel
+        const confirm = document.createElement("button")
+        confirm.type = "button"
+        confirm.className = "dshcm-dialog-button dshcm-dialog-confirm"
+        confirm.textContent = confirmLabel
+        actions.append(cancel, confirm)
+        dialog.append(heading, description, actions)
+        backdrop.appendChild(dialog)
+        document.body.appendChild(backdrop)
+
+        let settled = false
+        const finish = (value) => {
+          if (settled) return
+          settled = true
+          document.removeEventListener("keydown", onKeyDown, true)
+          backdrop.remove()
+          if (previousFocus instanceof HTMLElement && previousFocus.isConnected) previousFocus.focus()
+          resolve(value)
+        }
+        const onKeyDown = (event) => {
+          if (event.key === "Escape") { event.preventDefault(); finish(false) }
+          if (event.key === "Tab") {
+            event.preventDefault()
+            const target = event.shiftKey
+              ? (document.activeElement === cancel ? confirm : cancel)
+              : (document.activeElement === confirm ? cancel : confirm)
+            target.focus()
+          }
+        }
+        cancel.onclick = () => finish(false)
+        confirm.onclick = () => finish(true)
+        backdrop.onpointerdown = (event) => { if (event.target === backdrop) finish(false) }
+        document.addEventListener("keydown", onKeyDown, true)
+        cancel.focus()
+      })
+    }
+
     /**
      * 在系统资源管理器中打开一个目录路径。
      *
@@ -185,10 +309,10 @@ window.__ModuleLoader__.load({
           payload: { path },
         }),
       })
-      if (!response.ok) throw new Error(`打开失败: HTTP ${response.status}`)
+      if (!response.ok) throw new Error(t("openFailed", { reason: `HTTP ${response.status}` }))
       const full = await response.json()
       if (!full.result?.ok) {
-        throw new Error(`打开失败: ${full.result?.error?.message || "未知错误"}`)
+        throw new Error(t("openFailed", { reason: full.result?.error?.message || t("unknownError") }))
       }
     }
 
@@ -201,7 +325,7 @@ window.__ModuleLoader__.load({
       field.select()
       const copied = document.execCommand("copy")
       field.remove()
-      if (!copied) throw new Error("剪贴板不可用")
+      if (!copied) throw new Error(t("clipboardUnavailable"))
     }
 
     async function writeClipboard(text) {
@@ -215,7 +339,7 @@ window.__ModuleLoader__.load({
       if (navigator.clipboard?.readText) {
         try { return await navigator.clipboard.readText() } catch {}
       }
-      throw new Error("无法读取剪贴板，请使用 Ctrl+V")
+      throw new Error(t("clipboardReadFailed"))
     }
 
     async function copy(text, message) {
@@ -230,36 +354,55 @@ window.__ModuleLoader__.load({
 
     async function renameSession(sessions, row, session) {
       if (officialAction(row)) {
-        await officialSelect(row, [/^重命名$/i, /^rename$/i], "无法打开官方重命名窗口")
+        await officialSelect(row, [/^重命名$/i, /^rename$/i], t("officialRenameUnavailable"))
         return
       }
-      if (!session) throw new Error("无法确定当前会话")
-      const title = globalThis.prompt("重命名会话", session.displayTitle || session.title || "")
+      if (!session) throw new Error(t("sessionUnknown"))
+      const title = globalThis.prompt(t("renameSession"), session.displayTitle || session.title || "")
       if (title === null || title.trim() === (session.title || session.displayTitle)) return
-      if (!title.trim()) throw new Error("会话名称不能为空")
+      if (!title.trim()) throw new Error(t("sessionNameEmpty"))
       const binding = sessions.binding(session.id)
-      if (!binding) throw new Error("无法取得官方会话服务")
+      if (!binding) throw new Error(t("sessionServiceUnavailable"))
       const result = await binding.session.rename(title.trim())
-      if (!result.ok) throw new Error(result.error?.message || "重命名失败")
-      toast("会话已重命名")
+      if (!result.ok) throw new Error(result.error?.message || t("renameFailed"))
+      toast(t("sessionRenamed"))
     }
 
     async function archiveSession(workspaces, row, session) {
       if (officialAction(row)) {
-        await officialSelect(row, [/^归档会话$/i, /^archive( session)?$/i], "无法调用官方归档会话")
+        await officialSelect(row, [/^归档会话$/i, /^archive( session)?$/i], t("officialArchiveUnavailable"))
         return
       }
-      if (!session) throw new Error("无法确定当前会话")
+      if (!session) throw new Error(t("sessionUnknown"))
       await workspaces.archiveSession(session.id)
-      toast("会话已归档")
+      toast(t("sessionArchived"))
+    }
+
+    async function deleteSession(session) {
+      if (!session) throw new Error(t("sessionUnknown"))
+      const title = session.displayTitle || session.title || session.id
+      const confirmed = await confirmDialog({
+        title: t("deleteSessionDialogTitle"),
+        message: t("deleteSessionConfirm", { title }),
+        confirmLabel: t("confirmDelete"),
+        cancelLabel: t("cancel"),
+      })
+      if (!confirmed) return
+      try {
+        await fetch("/dsh-session-context-menu/delete", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ sessionId: session.id }),
+        })
+      } catch {}
     }
 
     async function forkSession(sessions, row, session) {
       if (officialAction(row)) {
-        await officialSelect(row, [/^分叉会话$/i, /^fork( session)?$/i], "无法调用官方分叉会话")
+        await officialSelect(row, [/^分叉会话$/i, /^fork( session)?$/i], t("officialForkUnavailable"))
         return
       }
-      if (!session) throw new Error("无法确定当前会话")
+      if (!session) throw new Error(t("sessionUnknown"))
       const childId = await sessions.fork({ sessionId: session.id, increaseTitle: true })
       sessions.open(childId)
     }
@@ -267,16 +410,16 @@ window.__ModuleLoader__.load({
     async function archiveWorkspaceSessions(workspaces, workspace) {
       const archived = new Set(workspaces.list.getSnapshot().archivedSessionIds)
       const sessionIds = workspace.sessionIds.filter((id) => !archived.has(id))
-      if (!sessionIds.length) { toast("该工作区没有可归档的会话"); return }
-      if (!globalThis.confirm(`归档“${workspace.title}”中的 ${sessionIds.length} 个会话？`)) return
+      if (!sessionIds.length) { toast(t("noWorkspaceSessions")); return }
+      if (!globalThis.confirm(t("archiveWorkspaceConfirm", { title: workspace.title, count: sessionIds.length }))) return
       for (const id of sessionIds) await workspaces.archiveSession(id)
-      toast(`已归档 ${sessionIds.length} 个会话`)
+      toast(t("workspaceSessionsArchived", { count: sessionIds.length }))
     }
 
     async function removeWorkspace(workspaces, workspace) {
-      if (!globalThis.confirm(`从 Harness 中移除工作区“${workspace.title}”？\n\n目录、文件和会话日志不会被删除。`)) return
+      if (!globalThis.confirm(t("removeWorkspaceConfirm", { title: workspace.title }))) return
       await workspaces.delete(workspace.workspaceId)
-      toast("已移除工作区")
+      toast(t("workspaceRemoved"))
     }
 
     function apply(ctx) {
@@ -291,10 +434,11 @@ window.__ModuleLoader__.load({
       let menu = null
       const close = () => { menu?.remove(); menu = null }
 
-      const add = (root, label, run, shortcut = "") => {
+      const add = (root, label, run, shortcut = "", danger = false) => {
         const button = document.createElement("button")
         button.type = "button"
         button.className = "dshcm-item"
+        if (danger) button.classList.add("dshcm-item--danger")
         button.setAttribute("role", "menuitem")
         button.tabIndex = -1
         const text = document.createElement("span")
@@ -343,7 +487,7 @@ window.__ModuleLoader__.load({
           editable.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: value }))
         } else {
           const selection = globalThis.getSelection()
-          if (!selection?.rangeCount || !editable.contains(selection.anchorNode)) throw new Error("无法确定编辑位置")
+          if (!selection?.rangeCount || !editable.contains(selection.anchorNode)) throw new Error(t("editPositionUnknown"))
           const range = selection.getRangeAt(0)
           range.deleteContents()
           const text = document.createTextNode(value)
@@ -435,18 +579,19 @@ window.__ModuleLoader__.load({
         }))
 
         if (row) {
-          add(root, "重命名会话", () => renameSession(sessions, row, session))
-          add(root, "归档会话", () => archiveSession(workspaces, row, session))
+          add(root, t("renameSession"), () => renameSession(sessions, row, session))
+          add(root, t("archiveSession"), () => archiveSession(workspaces, row, session))
+          add(root, t("deleteSession"), () => deleteSession(session), "", true)
           const cwd = session?.cwd || sessionWorkspace?.workspace.path
           if (cwd) {
             split(root)
-            add(root, "在资源管理器中打开", () => openInExplorer(cwd))
-            add(root, "复制工作目录", () => copy(cwd, "已复制工作目录"))
+            add(root, t("openInExplorer"), () => openInExplorer(cwd))
+            add(root, t("copyWorkingDirectory"), () => copy(cwd, t("copiedWorkingDirectory")))
           }
-          if (session) add(root, "复制会话 ID", () => copy(session.id, "已复制会话 ID"))
+          if (session) add(root, t("copySessionId"), () => copy(session.id, t("copiedSessionId")))
 
           split(root)
-          add(root, "创建会话分支", () => forkSession(sessions, row, session))
+          add(root, t("forkSession"), () => forkSession(sessions, row, session))
 
           const extensions = session
             ? registeredExtensions.filter((entry) => entry.visible?.({ session, row }) !== false)
@@ -456,48 +601,48 @@ window.__ModuleLoader__.load({
             for (const entry of extensions) add(root, entry.label || entry.id, () => entry.run({ session, row, sessions, workspaces, close }))
           }
           split(root)
-          add(root, "刷新", () => globalThis.location.reload(), "Ctrl+R")
+          add(root, t("refresh"), () => globalThis.location.reload(), "Ctrl+R")
         } else if (workspaceTarget) {
           const workspace = workspaceTarget.workspace
-          add(root, "新建会话", () => workspaces.startSession(workspace.workspaceId))
-          add(root, "在资源管理器中打开", () => openInExplorer(workspace.path))
+          add(root, t("newSession"), () => workspaces.startSession(workspace.workspaceId))
+          add(root, t("openInExplorer"), () => openInExplorer(workspace.path))
           split(root)
-          add(root, "重命名工作区", () => officialWorkspaceSelect(
+          add(root, t("renameWorkspace"), () => officialWorkspaceSelect(
             workspaceTarget.row,
             [/^重命名$/i, /^rename$/i],
-            "无法打开官方工作区重命名窗口",
+            t("officialWorkspaceRenameUnavailable"),
           ))
-          add(root, "复制工作区路径", () => copy(workspace.path, "已复制工作区路径"))
+          add(root, t("copyWorkspacePath"), () => copy(workspace.path, t("copiedWorkspacePath")))
           split(root)
-          add(root, "归档工作区会话", () => archiveWorkspaceSessions(workspaces, workspace))
-          add(root, "移除工作区", () => removeWorkspace(workspaces, workspace))
+          add(root, t("archiveWorkspaceSessions"), () => archiveWorkspaceSessions(workspaces, workspace))
+          add(root, t("removeWorkspace"), () => removeWorkspace(workspaces, workspace))
           split(root)
-          add(root, "刷新", () => globalThis.location.reload(), "Ctrl+R")
+          add(root, t("refresh"), () => globalThis.location.reload(), "Ctrl+R")
         } else if (editable) {
-          add(root, "撤销", () => { editable.focus(); if (!document.execCommand("undo")) throw new Error("请使用 Ctrl+Z 撤销") }, "Ctrl+Z")
-          add(root, "重做", () => { editable.focus(); if (!document.execCommand("redo")) throw new Error("请使用 Ctrl+Y 重做") }, "Ctrl+Y")
+          add(root, t("undo"), () => { editable.focus(); if (!document.execCommand("undo")) throw new Error(t("useUndoShortcut")) }, "Ctrl+Z")
+          add(root, t("redo"), () => { editable.focus(); if (!document.execCommand("redo")) throw new Error(t("useRedoShortcut")) }, "Ctrl+Y")
           split(root)
-          add(root, "剪切", async () => { if (selection) await copy(selection, "已剪切"); deleteSelection(editable) }, "Ctrl+X")
-          add(root, "复制", () => copy(selection, "已复制"), "Ctrl+C")
-          add(root, "粘贴", async () => replaceSelection(editable, await readClipboard()), "Ctrl+V")
+          add(root, t("cut"), async () => { if (selection) await copy(selection, t("cutDone")); deleteSelection(editable) }, "Ctrl+X")
+          add(root, t("copy"), () => copy(selection, t("copied")), "Ctrl+C")
+          add(root, t("paste"), async () => replaceSelection(editable, await readClipboard()), "Ctrl+V")
           split(root)
-          add(root, "全选", () => selectAll(editable), "Ctrl+A")
+          add(root, t("selectAll"), () => selectAll(editable), "Ctrl+A")
           split(root)
-          add(root, "刷新", () => globalThis.location.reload(), "Ctrl+R")
+          add(root, t("refresh"), () => globalThis.location.reload(), "Ctrl+R")
         } else {
-          if (selection) add(root, "复制所选文本", () => copy(selection, "已复制"), "Ctrl+C")
+          if (selection) add(root, t("copySelectedText"), () => copy(selection, t("copied")), "Ctrl+C")
           const url = link?.href || selectedUrl(selection)
           if (url) {
             if (selection) split(root)
-            add(root, "使用默认浏览器打开", () => workspaces.openPath(url))
-            add(root, "复制链接", () => copy(url, "已复制链接"))
+            add(root, t("openInDefaultBrowser"), () => workspaces.openPath(url))
+            add(root, t("copyLink"), () => copy(url, t("linkCopied")))
           }
           if (surface) {
             if (selection || url) split(root)
-            add(root, "全选当前内容", () => selectSurface(surface), "Ctrl+A")
+            add(root, t("selectCurrentContent"), () => selectSurface(surface), "Ctrl+A")
           }
           split(root)
-          add(root, "刷新", () => globalThis.location.reload(), "Ctrl+R")
+          add(root, t("refresh"), () => globalThis.location.reload(), "Ctrl+R")
         }
         position(root, event)
       }
@@ -522,7 +667,7 @@ window.__ModuleLoader__.load({
       return () => {
         if (disposed) return
         disposed = true
-        close(); style.remove()
+        close(); document.querySelector(".dshcm-dialog-backdrop")?.querySelector("[data-cancel]")?.click(); style.remove()
         document.removeEventListener("contextmenu", onContextMenu, true)
         document.removeEventListener("pointerdown", outside, true)
         document.removeEventListener("keydown", keyboard, true)

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,205 @@
-export const inject = []
+import { existsSync } from "node:fs"
+import { rm } from "node:fs/promises"
+import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path"
 
-export function apply() {}
+export const inject = ["webServer", "sessionPersistence", "workspaceRegistry", "agents", "sessions", "storageDomain"]
+
+const DELETE_ROUTE = "/dsh-session-context-menu/delete"
+const MAX_BODY_BYTES = 64 * 1024
+const SESSION_ID_RE = /^[A-Za-z0-9_-]+$/
+
+function readJsonBody(request) {
+  return new Promise((resolve, reject) => {
+    let data = ""
+    request.on("data", (chunk) => {
+      data += chunk
+      if (data.length > MAX_BODY_BYTES) {
+        request.destroy()
+        reject(new Error("request body too large"))
+      }
+    })
+    request.on("end", () => {
+      try { resolve(data ? JSON.parse(data) : {}) } catch { reject(new Error("invalid JSON body")) }
+    })
+    request.on("error", reject)
+  })
+}
+
+function respond(response, status, payload) {
+  const body = JSON.stringify(payload)
+  response.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "content-length": Buffer.byteLength(body),
+  })
+  response.end(body)
+}
+
+async function stopAgent(agent) {
+  if (!agent) return
+  if (typeof agent.cancel === "function") {
+    try { agent.cancel({ kind: "user" }, { keepInbox: true }) } catch {}
+  }
+  if (typeof agent.whenIdle === "function") {
+    await new Promise((resolve) => {
+      const timer = setTimeout(resolve, 15_000)
+      Promise.resolve(agent.whenIdle()).then(
+        () => { clearTimeout(timer); resolve() },
+        () => { clearTimeout(timer); resolve() },
+      )
+    })
+  }
+}
+
+async function detachLiveSession(ctx, sessionId) {
+  const sessions = ctx.get("sessions")
+  const session = sessions?.get?.(sessionId)
+  if (!session) return false
+  if (typeof sessions.flush === "function") {
+    try { await sessions.flush(session) } catch {}
+  }
+  const entry = sessions.store?.get?.(sessionId)
+  if (!entry) return false
+  if (typeof sessions.detachEntered === "function") sessions.detachEntered(entry)
+  else sessions.store.delete(sessionId)
+  return true
+}
+
+async function removeProjection(ctx, sessionId) {
+  const domain = ctx.storageDomain.get("session_projcache")
+  const sessions = domain?.table?.("sessions")
+  if (sessions?.get(sessionId) !== undefined) await sessions.delete(sessionId)
+}
+
+async function removeWorkspaceAccounting(ctx, sessionId) {
+  const domain = ctx.storageDomain.get("workspace")
+  if (!domain) return
+  for (const workspace of ctx.workspaceRegistry.list()) {
+    if (workspace.sessionIds.includes(sessionId)) await workspace.detachSession(sessionId)
+  }
+  const state = domain.global?.get?.()
+  if (state?.archivedSessionIds?.includes(sessionId)) {
+    const next = {
+      ...state,
+      archivedSessionIds: state.archivedSessionIds.filter((id) => id !== sessionId),
+    }
+    if (typeof ctx.workspaceRegistry.setState === "function") await ctx.workspaceRegistry.setState(next)
+    else {
+      await domain.global.set(next)
+      if ("state" in ctx.workspaceRegistry) ctx.workspaceRegistry.state = next
+    }
+  }
+}
+
+function safeSessionDirectory(location, sessionId) {
+  const dshHome = process.env.DSH_HOME
+  if (!dshHome) throw new Error("DSH_HOME is unavailable")
+  const sessionsRoot = resolve(dshHome, "sessions")
+  const sessionDir = resolve(dirname(location.path))
+  const fromRoot = relative(sessionsRoot, sessionDir)
+  const outsideRoot = !fromRoot || fromRoot === ".." || fromRoot.startsWith(`..${sep}`) || isAbsolute(fromRoot)
+  if (outsideRoot || basename(sessionDir) !== sessionId) {
+    throw new Error(`refusing unsafe session directory: ${sessionDir}`)
+  }
+  return sessionDir
+}
+
+async function archiveForTransition(ctx, sessionId) {
+  try {
+    await ctx.workspaceRegistry.archiveSession(sessionId)
+    return
+  } catch (error) {
+    const state = ctx.storageDomain.get("workspace")?.global?.get?.()
+    if (!state || state.archivedSessionIds.includes(sessionId)) throw error
+    const next = { ...state, archivedSessionIds: [...state.archivedSessionIds, sessionId] }
+    if (typeof ctx.workspaceRegistry.setState === "function") await ctx.workspaceRegistry.setState(next)
+    else {
+      await ctx.storageDomain.get("workspace").global.set(next)
+      if ("state" in ctx.workspaceRegistry) ctx.workspaceRegistry.state = next
+    }
+  }
+}
+
+async function removeAndVerify(sessionDir) {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await rm(sessionDir, { recursive: true, force: true })
+    await new Promise((resolve) => setImmediate(resolve))
+  }
+  if (existsSync(sessionDir)) throw new Error(`session directory still exists: ${sessionDir}`)
+}
+
+async function deleteSession(ctx, sessionId) {
+  const header = (await ctx.sessionPersistence.list()).find((item) => item.id === sessionId)
+  if (!header) throw new Error("session not found")
+  if (header.origin === "subagent") throw new Error("subagent session cannot be deleted directly")
+  const location = ctx.sessionPersistence.locate(header)
+  if (location?.kind !== "jsonl" || typeof location.path !== "string") {
+    throw new Error("session does not use deletable JSONL persistence")
+  }
+  const sessionDir = safeSessionDirectory(location, sessionId)
+  await stopAgent(ctx.agents.get(sessionId))
+  const detached = await detachLiveSession(ctx, sessionId)
+
+  await removeAndVerify(sessionDir)
+  const warnings = []
+  try { await removeProjection(ctx, sessionId) } catch (error) {
+    warnings.push("projection-cleanup-failed")
+    ctx.logger.warn(`[dsh-session-context-menu] failed to clean projection ${sessionId}:`, error)
+  }
+  await removeAndVerify(sessionDir)
+
+  // Preserve the official UI transition only after durable deletion succeeds:
+  // another selected session stays open; deleting the current one clears into
+  // the default New Session view.
+  try { await archiveForTransition(ctx, sessionId) } catch (error) {
+    warnings.push("archive-transition-failed")
+    ctx.logger.warn(`[dsh-session-context-menu] failed to transition deleted session ${sessionId}:`, error)
+  }
+  try { await removeWorkspaceAccounting(ctx, sessionId) } catch (error) {
+    warnings.push("workspace-cleanup-failed")
+    ctx.logger.warn(`[dsh-session-context-menu] failed to clean workspace accounting ${sessionId}:`, error)
+  }
+
+  return { ok: true, removed: true, detached, warnings }
+}
+
+export function apply(ctx) {
+  let mutationTail = Promise.resolve()
+  const withMutationLock = (operation) => {
+    const result = mutationTail.then(operation, operation)
+    mutationTail = result.then(() => undefined, () => undefined)
+    return result
+  }
+
+  return ctx.webServer.register({
+    kind: "exact",
+    path: DELETE_ROUTE,
+    handler: async (request, response) => {
+      if (request.method !== "POST") return respond(response, 405, { ok: false, error: "method-not-allowed" })
+      const contentType = request.headers?.["content-type"] || ""
+      if (!/^application\/json(?:\s*;|$)/i.test(contentType)) {
+        return respond(response, 415, { ok: false, error: "unsupported-media-type" })
+      }
+      const origin = request.headers?.origin
+      const host = request.headers?.host
+      if (origin && host) {
+        let sameOrigin = false
+        try { sameOrigin = new URL(origin).host === host } catch {}
+        if (!sameOrigin) return respond(response, 403, { ok: false, error: "cross-origin-request" })
+      }
+      let body
+      try { body = await readJsonBody(request) } catch { return respond(response, 400, { ok: false, error: "bad-request" }) }
+      const sessionId = body?.sessionId
+      if (typeof sessionId !== "string" || !SESSION_ID_RE.test(sessionId)) {
+        return respond(response, 400, { ok: false, error: "invalid-session-id" })
+      }
+      return withMutationLock(async () => {
+        try {
+          respond(response, 200, await deleteSession(ctx, sessionId))
+        } catch (error) {
+          ctx.logger.warn(`[dsh-session-context-menu] failed to delete session ${sessionId}:`, error)
+          respond(response, 500, { ok: false, error: "delete-failed" })
+        }
+      })
+    },
+  })
+}


### PR DESCRIPTION
## Why

The injected context menu remained Chinese when the Harness host UI was English, causing the inconsistency reported in #2. The stock archive action also only hides sessions while their logs remain on disk, so users need a deliberate and safe way to permanently delete a session from the same menu.

## What Changed

- Added a lightweight Chinese/English message dictionary that follows the current host UI language for menu items, confirmations, toasts, and errors.
- Added a danger-styled **Delete session** action with an accessible confirmation dialog. Clicking the backdrop, Cancel, or Escape leaves the session unchanged.
- Added a host-side permanent-delete route that cancels and drains a live agent, detaches the live session, removes and verifies the JSONL artifact directory, and cleans projection and workspace accounting.
- Preserved official workspace navigation semantics: deleting a non-current session leaves the current conversation open, while deleting the current session clears into the default New Session view.
- Restricted deletion to same-origin JSON requests and validated that recursive deletion stays below the active DSH sessions root.

## Verification

- Exercised deletion against an isolated temporary DSH home and confirmed the session directory, live-session entry, projection row, workspace membership, and archive ID were all removed.
- Confirmed recursive deletion rejects an out-of-root target without modifying or archiving it.
- Confirmed cross-origin and non-JSON deletion requests return `403` and `415` respectively.
